### PR TITLE
Minor changes to support Mac OSX (tested on 10.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Build untrunc
 
     g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -I./libav-0.8.7 -L./libav-0.8.7/libavformat -lavformat -L./libav-0.8.7/libavcodec -lavcodec -L./libav-0.8.7/libavutil -lavutil -lpthread -lz
 
+### Mac OSX
+
+Follow the above steps for "Installing on other operating system", but use the following g++ command:
+
+	g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -I./libav-0.8.7 -L./libav-0.8.7/libavformat -lavformat -L./libav-0.8.7/libavcodec -lavcodec -L./libav-0.8.7/libavutil -lavutil -lpthread -lz -framework CoreFoundation -framework CoreVideo -framework VideoDecodeAcceleration -lbz2 -DOSX
+
 ## Arch package
 
 Jose1711 kindly provides an arch package here: https://aur.archlinux.org/packages/untrunc-git/

--- a/atom.cpp
+++ b/atom.cpp
@@ -7,8 +7,11 @@
 #include <iostream>
 
 #include <assert.h>
+#ifdef OSX
+#include "osx_endian.h"
+#else
 #include <endian.h>
-
+#endif
 using namespace std;
 
 

--- a/file.cpp
+++ b/file.cpp
@@ -20,7 +20,11 @@
 
 #include "file.h"
 #include <string>
+#ifdef OSX
+#include "osx_endian.h"
+#else
 #include <endian.h>
+#endif
 
 using namespace std;
 

--- a/osx_endian.h
+++ b/osx_endian.h
@@ -1,0 +1,33 @@
+#ifndef __FINK_ENDIANDEV_PKG_ENDIAN_H__
+#define __FINK_ENDIANDEV_PKG_ENDIAN_H__ 1
+
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * */
+
+#ifndef __APPLE__
+	#warning "This header file (endian.h) is MacOS X specific.\n"
+#endif	/* __APPLE__ */
+
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+
+#endif	/* __FINK_ENDIANDEV_PKG_ENDIAN_H__ */

--- a/track.cpp
+++ b/track.cpp
@@ -25,7 +25,11 @@
 #include <vector>
 #include <string.h>
 #include <assert.h>
+#ifdef OSX
+#include "osx_endian.h"
+#else
 #include <endian.h>
+#endif
 
 #define __STDC_LIMIT_MACROS 1
 #define __STDC_CONSTANT_MACROS 1


### PR DESCRIPTION
These commits should fix untrunc for OSX. I don't really know how to program and I found the header file on a github gist, but it's in the public domain and the content seems simple enough. Maybe this will help some poor souls stuck on Apple's OS.
