### PR TITLE
change all <endian> imports to OSX-compatible shims

### DIFF
--- a/atom.cpp
+++ b/atom.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 
 #include <assert.h>
-#include <endian.h>
+#include "endian.h"
 
 using namespace std;
 

--- a/endian.h
+++ b/endian.h
@@ -1,0 +1,35 @@
+#ifndef __UNTRUNC_ENDIAN_H__
+#define __UNTRUNC_ENDIAN_H__ 1
+
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * */
+
+#ifndef __APPLE__
+
+#include <endian.h>
+
+#else
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#endif	/* __APPLE__ */
+
+#endif	/* __UNTRUNC_ENDIAN_H__ */

--- a/file.cpp
+++ b/file.cpp
@@ -20,7 +20,7 @@
 
 #include "file.h"
 #include <string>
-#include <endian.h>
+#include "endian.h"
 
 using namespace std;
 

--- a/track.cpp
+++ b/track.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 #include <string.h>
 #include <assert.h>
-#include <endian.h>
+#include "endian.h"
 
 #define __STDC_LIMIT_MACROS 1
 #define __STDC_CONSTANT_MACROS 1


### PR DESCRIPTION
should fix #22 by using OSX shims for `endian` functions when compiling for Apple platforms, and `<endian.h>`
