### PR TITLE
fix compiler error on Mac of missing endian.h

### DIFF
--- a/atom.cpp
+++ b/atom.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 
 #include <assert.h>
-#include <endian.h>
+#include "uendian.h"
 
 using namespace std;
 

--- a/file.cpp
+++ b/file.cpp
@@ -20,7 +20,7 @@
 
 #include "file.h"
 #include <string>
-#include <endian.h>
+#include "uendian.h"
 
 using namespace std;
 

--- a/track.cpp
+++ b/track.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 #include <string.h>
 #include <assert.h>
-#include <endian.h>
+#include "uendian.h"
 
 #define __STDC_LIMIT_MACROS 1
 #define __STDC_CONSTANT_MACROS 1

--- a/uendian.h
+++ b/uendian.h
@@ -1,0 +1,33 @@
+#ifndef UENDIAN_H__
+#define UENDIAN_H__
+#include <inttypes.h>
+#include <string.h>
+
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__)
+#include <endian.h>
+#elif __FreeBSD__
+#include <sys/endian.h>
+#elif defined(__APPLE__) && defined(__MACH__)
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#else
+#error Couldn't find any appropriate endian.h
+#endif // PLATFORMS
+
+#endif // UENDIAN_H__


### PR DESCRIPTION
Originally if you compile untrunc on mac, you'll get `track.cpp:28:10: fatal error: 'endian.h' file not found`. But even if you switch to `<machine/endian.h>`, it'll still complain about `file.cpp:74:12: error: use of undeclared identifier 'be32toh'`. 

So solution is to provide `be32toh` with `OSSwapBigToHostInt32`, and so on. For windows we might have to implement ourselves but I'll leave it to someone really needs windows support to implement this.