### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:14.04
+
+RUN apt-get update
+RUN apt-get install -y libavformat-dev libavcodec-dev libavutil-dev
+ADD . /untrunc
+WORKDIR /untrunc
+RUN apt-get install -y g++
+RUN g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -L/usr/local/lib -lavformat -lavcodec -lavutil
+
+ENTRYPOINT bash


### PR DESCRIPTION
Because I work on Mac, I put things in containers. With this Dockerfile where I have a folder on my Desktop named `data` and a broken file named `broken.m4a` I was able to ...

```
$ git clone https://github.com/rjsteinert/untrunc.git
$ cd untrunc
$ docker build -t untrunc .
$ docker run -it --volume ~/Desktop/data/:/data untrunc 
$ ./untrunc /data/working.m4a /data/broken.m4a
$ exit
$ ls ~/Desktop/data/
broken.m4a      broken.m4a_fixed.mp4    working.m4a
```

It ran but the bummer for me is only 30 seconds of 41 minutes plays. I got a message of ...

```
Reading: /data/working.m4a
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/data/working.m4a':
  Metadata:
    major_brand     : M4A
    minor_version   : 0
    compatible_brands: M4A mp42isom
    creation_time   : 2016-08-22 14:43:54
    date            : 2016-08-22T10:43:13-0400
    encoder         : com.apple.VoiceMemos (iPhone OS 9.3.2)
  Duration: 00:00:37.29, start: 0.000000, bitrate: 65 kb/s
    Stream #0.0(und): Audio: aac, 44100 Hz, mono, fltp, 63 kb/s
    Metadata:
      creation_time   : 2016-08-22 14:43:54
[aac @ 0x1588b60] Input buffer exhausted before END element found
```

I bet that's a memory limit that got hit right? Any way to increase it?
