### PR TITLE
Allow getFragment to read out of bounds, where it just gives zeroes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -69,6 +69,9 @@ int main(int argc, char *argv[]) {
             mp4.repair(corrupt);
             mp4.saveVideo(corrupt + "_fixed.mp4");
         }
+    } catch (const char* s) {
+        cerr << s << endl;
+        return -1;
     } catch(string e) {
         cerr << e << endl;
         return -1;

--- a/track.cpp
+++ b/track.cpp
@@ -369,7 +369,7 @@ bool getNalInfo(H264sps &sps, uint32_t maxlength, uint8_t *buffer, NalInfo &info
 
 	if(len + 4 > maxlength) {
 		cout << "Buffer size exceeded\n";
-		return false;
+		len = maxlength - 4;
 	}
 	info.length = len + 4;
 	cout << "Length: " << info.length << "\n";


### PR DESCRIPTION
I needed to allow these accesses to repair a few videos. I also ran into #29 because of this, and I just added a catch block for it so it never happens again.