### PR TITLE
Small fixes to make untrunc work with a video containing lots of 0-bytes at the end

### DIFF
--- a/mp4.cpp
+++ b/mp4.cpp
@@ -341,7 +341,7 @@ void Mp4::repair(string filename) {
 	vector<int> audiotimes;
 	unsigned long count = 0;
 	off_t offset = 0;
-	while(offset < mdat->contentSize()) {
+	while(offset <= mdat->contentSize() - 4) {
 
 		//unsigned char *start = &(mdat->content[offset]);
 		int64_t maxlength = mdat->contentSize() - offset;


### PR DESCRIPTION
atom.cpp:
- Fix buffer reuse logic in getFragment(). (speeds up considerably when skipping over large blocks of zeros)
- Fix "Out of buffer" crash in readInt() when reading near the end of the file. (needed for a previous version of the fix; probably a no-op now, but seems safer for the future)

mp4.cpp:
- Fix crash when the offset is < 4 bytes from the end of the block, i.e. a full int cannot be read.