### PR TITLE
Add info about CentOS 7 Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ You need:
 * [Libav](https://libav.org/)
 * Basic ability to use a command line
 
+## Installing on CentOS 7
+
+    yum install https://extras.getpagespeed.com/release-el7-latest.rpm
+    yum install untrunc
 
 ## Installing on Ubuntu
 


### PR DESCRIPTION
Built a package for CentOS 7 [here](https://extras.getpagespeed.com/redhat/7/x86_64/repoview/untrunc.html).

Can be installed according to [blog post](https://www.getpagespeed.com/uncategorized/untrunc).

P.S. if you can tag a release, i.e. 1.0.0 that would be great for further packaging efforts.