### PR TITLE
Fix libav version for Mac OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ On macOS add the following (tested on OSX 10.12.6):
 
 Follow the above steps for "Installing on other operating system", but use the following g++ command:
 
-	g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -I./libav-0.8.7 -L./libav-0.8.7/libavformat -lavformat -L./libav-0.8.7/libavcodec -lavcodec -L./libav-0.8.7/libavutil -lavutil -lpthread -lz -framework CoreFoundation -framework CoreVideo -framework VideoDecodeAcceleration -lbz2 -DOSX
+	g++ -o untrunc file.cpp main.cpp track.cpp atom.cpp mp4.cpp -I./libav-12.3 -L./libav-12.3/libavformat -lavformat -L./libav-12.3/libavcodec -lavcodec -L./libav-12.3/libavresample -lavresample -L./libav-12.3/libavutil -lavutil -lpthread -lz -framework CoreFoundation -framework CoreVideo -framework VideoDecodeAcceleration -lbz2 -DOSX
 
 ## Arch package
 


### PR DESCRIPTION
Ref: https://github.com/ponchio/untrunc/issues/154#issuecomment-465505327

Fixed for convenience.
- libav is old
- requires `libavresample`