### PR TITLE
decrese compiler proccess number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN wget https://github.com/libav/libav/archive/v12.3.zip && \
 
 # build libav
 WORKDIR /untrunc/libav-12.3/
-RUN ./configure && make -j
+RUN ./configure && make -j8
 
 # build untrunc
 WORKDIR /untrunc


### PR DESCRIPTION
decreasing as otherwise compiler uses quite a lot of memory and get killed by OOM killer  

-j [jobs], --jobs[=jobs]
            Specifies the number of jobs (commands) to run simultaneously.  If
            there  is  more than one -j option, the last one is effective.  If
            the -j option is given without an argument, make  will  not  limit
            the number of jobs that can run simultaneously.