### PR TITLE
Samsung GEAR360 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.cpp.o:
-	g++ -g -c $< -I./libav-12.3 
+.cpp.o:*.h
+	g++ -g -c $< -I./libav 
 
 all:file.o main.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o codec_alac.o codec_apch.o codec_avc1.o codec_fdsc.o codec_gpmd.o codec_hev1.o codec_mbex.o codec_mijd.o codec_mp4a.o codec_mp4v.o codec_pcm.o codec_rtp.o codec_text.o codec_tmcd.o codec_unknown.o
-	g++ -g -o untrunc -I./libav-12.3 main.o file.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o -L./libav-12.3/libavformat -lavformat -L./libav-12.3/libavcodec -lavcodec -L./libav-12.3/libavresample -lavresample -L./libav-12.3/libavutil -lavutil -lpthread -lz -lX11 -lvdpau
+	g++ -g -o untrunc -I./libav main.o file.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o -L./libav/libavformat -lavformat -L./libav/libavcodec -lavcodec -L./libav/libavresample -lavresample -L./libav/libavutil -lavutil -lpthread -lz -lX11 -lvdpau

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.cpp.o:*.h
-	g++ -g -c $< -I./libav 
+.cpp.o:*.h Makefile
+	g++ -g -D __GEAR360__ -c $< -I./libav 
 
 all:file.o main.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o codec_alac.o codec_apch.o codec_avc1.o codec_fdsc.o codec_gpmd.o codec_hev1.o codec_mbex.o codec_mijd.o codec_mp4a.o codec_mp4v.o codec_pcm.o codec_rtp.o codec_text.o codec_tmcd.o codec_unknown.o
 	g++ -g -o untrunc -I./libav main.o file.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o -L./libav/libavformat -lavformat -L./libav/libavcodec -lavcodec -L./libav/libavresample -lavresample -L./libav/libavutil -lavutil -lpthread -lz -lX11 -lvdpau

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.cpp.o:
+	g++ -g -c $< -I./libav-12.3 
+
+all:file.o main.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o codec_alac.o codec_apch.o codec_avc1.o codec_fdsc.o codec_gpmd.o codec_hev1.o codec_mbex.o codec_mijd.o codec_mp4a.o codec_mp4v.o codec_pcm.o codec_rtp.o codec_text.o codec_tmcd.o codec_unknown.o
+	g++ -g -o untrunc -I./libav-12.3 main.o file.o track.o atom.o codec_*.o codecstats.o codec.o mp4.o log.o -L./libav-12.3/libavformat -lavformat -L./libav-12.3/libavcodec -lavcodec -L./libav-12.3/libavresample -lavresample -L./libav-12.3/libavutil -lavutil -lpthread -lz -lX11 -lvdpau

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cd ..
 g++ -o untrunc -I./libav file.cpp main.cpp track.cpp atom.cpp codec_*.cpp codecstats.cpp codec.cpp mp4.cpp log.cpp -L./libav/libavformat -lavformat -L./libav/libavcodec -lavcodec -L./libav/libavresample -lavresample -L./libav/libavutil -lavutil -lpthread -lz
 sudo install -vpm 755 ./untrunc /usr/local/bin/
 which -a untrunc
+```  
+If compiling for Samsung GEAR 360:  
+```bash
+g++ -o untrunc -D __GEAR360__ -I./libav file.cpp main.cpp track.cpp atom.cpp codec_*.cpp codecstats.cpp codec.cpp mp4.cpp log.cpp -L./libav/libavformat -lavformat -L./libav/libavcodec -lavcodec -L./libav/libavresample -lavresample -L./libav/libavutil -lavutil -lpthread -lz
+sudo install -vpm 755 ./untrunc /usr/local/bin/
+which -a untrunc
 ```
 
 Depending on your system and Libav configure options you might need to add extra flags to the command line:

--- a/codec.cpp
+++ b/codec.cpp
@@ -87,6 +87,7 @@ Match Codec::match(const unsigned char *start, int maxlength) {
 
 	} else if(name == "mp4a") {
 		return mp4aMatch(start, maxlength);
+
 	} else if(name == "mp4v") {
 		return mp4vMatch(start, maxlength);
 

--- a/codec_hev1.cpp
+++ b/codec_hev1.cpp
@@ -1,4 +1,5 @@
 #include "codec.h"
+#include "log.h"
 
 
 using namespace std;
@@ -99,12 +100,16 @@ Match Codec::hev1Match(const unsigned char *start, int maxlength) {
 	Match match;
 
 	const unsigned char *pos = start;
-
+	int iter=0;
+	
 	H265NalInfo previous_nal;
 
 	while(1) {
+		iter++;
+		Log::debug << "In While loop [" << iter << "] :" << (void *) pos  << '\n';
 		H265NalInfo nal_info(pos, maxlength);
-		if(!nal_info.is_ok)
+		// I never have more than 2 iterations in this test for Gear 360
+		if((!nal_info.is_ok)|| (iter >=2 ))
 			return match;
 
 		if (nal_info.isKeyFrame())

--- a/codec_hev1.cpp
+++ b/codec_hev1.cpp
@@ -108,8 +108,14 @@ Match Codec::hev1Match(const unsigned char *start, int maxlength) {
 		iter++;
 		Log::debug << "In While loop [" << iter << "] :" << (void *) pos  << '\n';
 		H265NalInfo nal_info(pos, maxlength);
+#ifdef __GEAR360__
 		// I never have more than 2 iterations in this test for Gear 360
+		// In case I find 3 iteratinons that this leads to an error in 
+		// content parsing
 		if((!nal_info.is_ok)|| (iter >=2 ))
+#else
+		if (!nal_info.is_ok)
+#endif
 			return match;
 
 		if (nal_info.isKeyFrame())

--- a/main.cpp
+++ b/main.cpp
@@ -157,13 +157,15 @@ int main(int argc, char *argv[]) {
 			mp4.printAtoms();
 		}
 		if(analyze) {
+			Log::debug << "Main->Analyze" << endl;
 			mp4.analyze(analyze_track);
 		}
 		if(simulate)
+			Log::debug << "Main->Simulate" << endl;
 			mp4.simulate(mdat_strategy, mdat_begin);
 
 		if(corrupt.size()) {
-
+			Log::debug << "Main->Repair" << endl;
 			bool success = mp4.repair(corrupt, mdat_strategy, mdat_begin, skip_zeros, drifting);
 			//if the user didn't specify the strategy, try them all.
 			if(!success  && mdat_strategy == Mp4::FIRST) {

--- a/mp4.cpp
+++ b/mp4.cpp
@@ -1000,6 +1000,7 @@ double entropy(uint8_t *data, int size) {
 	return e;
 }
 
+#ifdef __GEAR360__
 int Mp4::align_128bit (int input){
 	
 	int reminder=input % 16;
@@ -1015,6 +1016,7 @@ int Mp4::align_128bit (int input){
 	return (output);
 
 }
+#endif
 
 bool Mp4::repair(string corrupt_filename, Mp4::MdatStrategy strategy, int64_t mdat_begin, bool skip_zeros, bool drifting) {
 	Log::info << "Repair: " << corrupt_filename << '\n';
@@ -1117,8 +1119,11 @@ bool Mp4::repair(string corrupt_filename, Mp4::MdatStrategy strategy, int64_t md
 	int percent = 0;
 	//keep track of how many backtraced.
 	int backtracked = 0;
+#ifdef __GEAR360_TEST__
 	int track0=0;
 	int track1=0;
+#endif
+
 	while(offset <  mdat->contentSize()) {
 		int p = 100*offset / mdat->contentSize();
 		if(p > percent) {
@@ -1271,9 +1276,11 @@ bool Mp4::repair(string corrupt_filename, Mp4::MdatStrategy strategy, int64_t md
 						tracks[candidate.id].codec.tmcd_seen = true;
 					offset = last.offset + candidate.length;
 
-					// Arrotonda il prossimo offset allineato a 16 byte
+#ifdef __GEAR360__
+					// offsets are 128 bit aligned
 					offset = align_128bit(offset);
 					Log::debug << "New offset: " << offset<< endl;	
+#endif
 					break;
 				}
 				//no luck either, try another one looping
@@ -1296,17 +1303,20 @@ bool Mp4::repair(string corrupt_filename, Mp4::MdatStrategy strategy, int64_t md
 			offset += best.length;
 			Log::debug << "New offset best length: " << offset<< endl;
 			Log::debug << "Allinea 16: " << offset % 16<< endl;
-			// FDA allinea a 16 byte
+#ifdef __GEAR360__
+			// offsets are 128 bit aligned
 			offset = align_128bit(offset);
 			Log::debug << "New offset: " << offset<< endl;
+#endif
+
+// Used when processing a correct file to see if every chunk is properly identified. 
+// Stops when next offset is not aligned with the known correct value
+#ifdef __GEAR360_TEST__
 			if (best.id==0)
 				track0++;
 			else 
 				track1++;
 
-// Used when processing a correct file to see if every chunk is properly identified. 
-// Stops when next offset is not aligned with the known correct value
-#ifdef __FDA_TEST__
 			Log::debug << "New offset 0[" << track0 <<"] "<< tracks[0].offsets[track0]-64 << "size: "<<tracks[0].chunk_sizes[track0] <<endl;
 			Log::debug << "New offset 1[" << track1 <<"] "<< tracks[1].offsets[track1]-64 << "size: "<<tracks[1].chunk_sizes[track1]<< endl;
 
@@ -1328,9 +1338,11 @@ bool Mp4::repair(string corrupt_filename, Mp4::MdatStrategy strategy, int64_t md
 			}
 			offset += best.length;
 			Log::debug << "New offset best length: " << offset<< endl;
-			// FDA allinea a 16 byte
+#ifdef __GEAR360__
+			// offsets are 128 bit aligned
 			offset = align_128bit(offset);
 			Log::debug << "New offset: " << offset<< endl;
+#endif
 
 			//This should only happen with pcm codecs, and here we should search for the beginning of another codec
 		}

--- a/mp4.h
+++ b/mp4.h
@@ -71,6 +71,8 @@ public:
 
     static bool makeStreamable(std::string filename, std::string output_filename);
 
+	int align_128bit (int input);
+
 protected:
     std::string file_name;
     Atom *root;

--- a/mp4.h
+++ b/mp4.h
@@ -70,8 +70,9 @@ public:
 	void simulate(MdatStrategy strategy, int64_t begin);
 
     static bool makeStreamable(std::string filename, std::string output_filename);
-
+#ifdef __GEAR360__
 	int align_128bit (int input);
+#endif
 
 protected:
     std::string file_name;

--- a/track.cpp
+++ b/track.cpp
@@ -141,6 +141,8 @@ bool Track::parse(Atom *t) {
 	{
 		AvLog useAvLog();
 		codec.codec = avcodec_find_decoder(codec.context->codec_id);
+		Log::debug << "Codec: " << codec.codec << "\n";
+
 		if(!codec.codec) {
 			Log::info <<  "No codec found for track of type: " << type << "\n";
 			return true;
@@ -317,6 +319,7 @@ void Track::getKeyframes(Atom *t) {
 void Track::getSampleSizes(Atom *t) {
 	assert(t != NULL);
 	sample_sizes.clear();
+	chunk_sizes.clear();
 	// Chunk offsets.
 	Atom *stsz = t->atomByName("stsz");
 	if(!stsz)
@@ -326,8 +329,11 @@ void Track::getSampleSizes(Atom *t) {
 	default_size = stsz->readInt(4);
 
 	if(default_size == 0) {
-		for(int i = 0; i < nsamples; i++)
-			sample_sizes.push_back(stsz->readInt(12 + 4*i));
+		for(int i = 0; i < nsamples; i++) {
+				sample_sizes.push_back(stsz->readInt(12 + 4*i));
+				chunk_sizes.push_back(stsz->readInt(12 + 4*i));
+			}
+
 	}
 }
 


### PR DESCRIPTION
Hi,
I'd like to thank you for your fantastic job. 
I often get the last chunk of the video corrupted because of hard landings or battery depletion and finally I was able to recover a lot of really precious videos :)

I just did a few updates in order to be able to recover videos recorded with Samsung Gear 360 camera (the first version of the camera the one that looks like a ball):
- I have a 128 bit aligned chunks 
- I also had to limit the number of NAL Units header in video stream since I was getting an error because, from time to time, it was finding a 3rd NAL Unit header in the loop cannibalizing part of the audio track and breaking the repair process).

I added changes related to __GEAR360__  using #ifdef to avoid breaking the code that is working for other cameras and because I didn't want to add an extra option in the command line (I'm too lazy :))

Hope this code can be useful to others.


