### PR TITLE
The git clone was missing the --recurse-submodules option to download the libav source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need:
 
 Type the folling commands to build from git :
 ```bash
-git clone https://github.com/ponchio/untrunc
+git clone --recurse-submodules https://github.com/ponchio/untrunc
 cd untrunc/libav
 ./configure
 make


### PR DESCRIPTION
The git clone was missing the --recurse-submodules to also download the libav source code.