### PR TITLE
The git clone command was uncomplete (it wasn't downloading the libav submodule)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need:
 
 Type the folling commands to build from git :
 ```bash
-git clone https://github.com/ponchio/untrunc
+git clone --recurse-submodules=libav https://github.com/ponchio/untrunc
 cd untrunc/libav
 ./configure
 make


### PR DESCRIPTION
The git clone was missing the `--recurse-submodules=libav` to also download the `libav` source code.