### PR TITLE
Add linking to bz2 on compilation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cd untrunc/libav
 ./configure
 make
 cd ..
-g++ -o untrunc -I./libav file.cpp main.cpp track.cpp atom.cpp codec_*.cpp codecstats.cpp codec.cpp mp4.cpp log.cpp -L./libav/libavformat -lavformat -L./libav/libavcodec -lavcodec -L./libav/libavresample -lavresample -L./libav/libavutil -lavutil -lpthread -lz -std=c++11
+g++ -o untrunc -I./libav file.cpp main.cpp track.cpp atom.cpp codec_*.cpp codecstats.cpp codec.cpp mp4.cpp log.cpp -L./libav/libavformat -lavformat -L./libav/libavcodec -lavcodec -L./libav/libavresample -lavresample -L./libav/libavutil -lavutil -lpthread -lz -lbz2 -std=c++11
 sudo install -vpm 755 ./untrunc /usr/local/bin/ 
 which -a untrunc
 ```


### PR DESCRIPTION
Without linking, the following error happens:

```
/usr/bin/ld: ./libav/libavformat/libavformat.a(matroskadec.o): in function `matroska_decode_buffer':
/home/dmelo/proj3/untrunc/libav/libavformat/matroskadec.c:1163: undefined reference to `BZ2_bzDecompressInit'
/usr/bin/ld: /home/dmelo/proj3/untrunc/libav/libavformat/matroskadec.c:1177: undefined reference to `BZ2_bzDecompress'
/usr/bin/ld: /home/dmelo/proj3/untrunc/libav/libavformat/matroskadec.c:1171: undefined reference to `BZ2_bzDecompressEnd'
/usr/bin/ld: /home/dmelo/proj3/untrunc/libav/libavformat/matroskadec.c:1180: undefined reference to `BZ2_bzDecompressEnd'
```

Running on Fedora 35:

```
❯ uname -a
Linux solomon 5.19.16-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Sun Oct 16 21:50:15 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```